### PR TITLE
build: upgrade to Node 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -247,7 +247,7 @@
   },
   "engines": {
     "npm": "please-use-yarn",
-    "node": "14",
+    "node": "16",
     "yarn": ">=1.22"
   }
 }


### PR DESCRIPTION
Vercel stopped supporting Node 14 recently. We cannot use Node 18 due to certain webpack dependencies, but Node 16 should get us building properly on Vercel again.